### PR TITLE
Improve URLs for paper as a PDF file

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
                 <a href="https://github.com/lupantech/ScienceQA" class="ext-link" target="blank">Code</a>
             </p>
             <p>
-                <a href="https://lupantech.github.io/papers/neurips22_ScienceQA.pdf" class="ext-link" target="blank">
+                <a href="https://lupantech.github.io/papers/neurips22_scienceqa.pdf" class="ext-link" target="blank">
                     <img src="./img/thumbnail.png" style="width: 100%;">
                 </a>
             </p>

--- a/index.html
+++ b/index.html
@@ -188,12 +188,12 @@
                 Ashwin Kalyan<br>
                 The 36th Conference on Neural Information Processing Systems (NeurIPS), 2022<br>
                 <a href="https://arxiv.org/abs/2209.09513" class="ext-link" target="blank">Paper</a> /
-                <a href="http://lupantech.github.io/papers/neurips22_scienceqa.pdf" class="ext-link"
+                <a href="https://lupantech.github.io/papers/neurips22_scienceqa.pdf" class="ext-link"
                     target="blank">PDF</a> /
                 <a href="https://github.com/lupantech/ScienceQA" class="ext-link" target="blank">Code</a>
             </p>
             <p>
-                <a href="http://lupantech.github.io/papers/neurips22_ScienceQA.pdf" class="ext-link" target="blank">
+                <a href="https://lupantech.github.io/papers/neurips22_ScienceQA.pdf" class="ext-link" target="blank">
                     <img src="./img/thumbnail.png" style="width: 100%;">
                 </a>
             </p>


### PR DESCRIPTION
1. Commit 4ce95eafb1a4446220616b9237536be562a14b67, just modifies a couple of the URLs in the `index.html` webpage, to specify "https" instead of "http", as their protocol. **I'm unsure whether or not you'd _want_ to merge this commit**.
2. Commit 798f685c718d52fee9418de501b1fef6419730af, however, fixes a **broken hyperlink** that existed in the `index.html` webpage, which had been **failing to link** to the **paper as a PDF file** hosted on GitHub, due to having had **incorrect casing** being used **in the filename which was specified** in the URL of the hyperlink.